### PR TITLE
fix org type edit also for /org/, closes #882

### DIFF
--- a/app/grails-app/views/org/orgType/_field.gsp
+++ b/app/grails-app/views/org/orgType/_field.gsp
@@ -1,0 +1,8 @@
+<div class="control-group ">
+	<label class="control-label" for="orgType">Org Type</label>
+	<div class="controls">
+		 <g:set value="${com.k_int.kbplus.RefdataCategory.findByDesc('OrgType')}" var="orgtypecat"/>
+		 <g:set value="${com.k_int.kbplus.RefdataValue.findAllByOwner(orgtypecat)}" var="refvalues"/>
+	   	 <g:select from="${refvalues}" optionKey="id" name="orgType" />
+	</div>
+</div>


### PR DESCRIPTION
@latusaki Thank you for your fast fix for /organisations/create and /organisations/edit/1!

To make /org/create and /org/edit/1 work, copy
app/grails-app/views/organisations/orgType/_field.gsp
to
app/grails-app/views/org/orgType/_field.gsp
