### PR TITLE
correctly print package id values on publicExport

### DIFF
--- a/app/grails-app/controllers/com/k_int/kbplus/PublicExportController.groovy
+++ b/app/grails-app/controllers/com/k_int/kbplus/PublicExportController.groovy
@@ -15,12 +15,14 @@ class PublicExportController {
   def index() { 
     def result = [:]
 
-    def base_qry = "from Package as p order by p.name asc"
-    def base_qry_fields = " p.id, p.name, id.value from Package as p LEFT JOIN p.ids as ido LEFT JOIN ido.identifier as id order by p.name asc"
-    def qry_params = []
+    result.packages = Package.executeQuery("select id, name, '' from Package order by name");
+    result.num_pkg_rows = result.packages.size()
 
-    result.num_pkg_rows = Package.executeQuery("select count(p) "+base_qry, qry_params )[0]
-    result.packages = Package.executeQuery("select ${base_qry_fields}", qry_params, [max:result.num_pkg_rows]);
+    result.packages.each {
+      it[2] = Package.executeQuery(
+        "select id.value from Package p JOIN p.ids as ido LEFT JOIN ido.identifier as id where p.id=?", [it[0]])
+    }
+
     result
   }
 


### PR DESCRIPTION
A value of "ZDB-1-MUS" is correctly displayed as identifier value on packageDetails/show/16. However, on https://kbplusdemo.gbv.de/kbplus/publicExport the value is split into characters, see screenshot:
![2015-04-28-package-id-values](https://cloud.githubusercontent.com/assets/533612/7376573/fa27473c-ede0-11e4-9daf-0c4c1668d689.png)

This pull request fixes it.
