### PR TITLE
google analytics into layouts/_analytics.gsp

### DIFF
--- a/app/grails-app/views/exports.gsp
+++ b/app/grails-app/views/exports.gsp
@@ -90,17 +90,5 @@
 
 <script src="js/plugins.js"></script>
 </body>
-<script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-32852294-1']);
-    _gaq.push(['_trackPageview']);
-    (function () {
-        var ga = document.createElement('script');
-        ga.type = 'text/javascript';
-        ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(ga, s);
-    })();
-</script>
+<tmpl:/layouts/analytics />
 </html>

--- a/app/grails-app/views/layouts/_analytics.gsp
+++ b/app/grails-app/views/layouts/_analytics.gsp
@@ -1,0 +1,28 @@
+<g:if test="${grailsApplication?.config?.kbplus?.analytics?.code}">
+  <r:script type="text/javascript">
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', '${grailsApplication.config.kbplus.analytics.code}']);
+      <g:if test="${params.shortcode != null}">
+      _gaq.push(['_setCustomVar',
+            1,                     // This custom var is set to slot #1.  Required parameter.
+            'Institution',         // The name acts as a kind of category for the user activity.  Required parameter.
+            "${params.shortcode}", // This value of the custom variable.  Required parameter.
+            2                      // Sets the scope to session-level.  Optional parameter.
+         ]);
+      </g:if>
+      <g:if test="${user?.defaultDash?.shortcode}">
+      _gaq.push(['_setCustomVar',
+            2,                     // This custom var is set to slot #2.  Required parameter.
+            'UserDefaultOrg',         // The name acts as a kind of category for the user activity.  Required parameter.
+            "${user?.defaultDash?.shortcode}", // This value of the custom variable.  Required parameter.
+            3                      // Sets the scope to page-level.  Optional parameter.
+         ]);
+      </g:if>
+      _gaq.push(['_trackPageview']);
+      (function() {
+          var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+          ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+  </r:script>
+</g:if>

--- a/app/grails-app/views/layouts/bootstrap.gsp
+++ b/app/grails-app/views/layouts/bootstrap.gsp
@@ -19,16 +19,7 @@
     <g:layoutHead/>
     <r:layoutResources/>
 
-    <r:script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', '${grailsApplication.config.kbplus.analytics.code}']);
-      _gaq.push(['_trackPageview']);
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </r:script>
+	<tmpl:/layouts/analytics />
   </head>
 
   <body>

--- a/app/grails-app/views/layouts/mmbootstrap.gsp
+++ b/app/grails-app/views/layouts/mmbootstrap.gsp
@@ -380,36 +380,9 @@
       </div>
   </div>
 
-
+  <tmpl:/layouts/analytics />
 
   <r:script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', '${grailsApplication.config.kbplus.analytics.code}']);
-      <g:if test="${params.shortcode != null}">
-      _gaq.push(['_setCustomVar',
-            1,                     // This custom var is set to slot #1.  Required parameter.
-            'Institution',         // The name acts as a kind of category for the user activity.  Required parameter.
-            "${params.shortcode}", // This value of the custom variable.  Required parameter.
-            2                      // Sets the scope to session-level.  Optional parameter.
-         ]);
-      </g:if>
-      <g:if test="${user?.defaultDash?.shortcode}">
-      _gaq.push(['_setCustomVar',
-            2,                     // This custom var is set to slot #2.  Required parameter.
-            'UserDefaultOrg',         // The name acts as a kind of category for the user activity.  Required parameter.
-            "${user?.defaultDash?.shortcode}", // This value of the custom variable.  Required parameter.
-            3                      // Sets the scope to page-level.  Optional parameter.
-         ]);
-      </g:if>
-      _gaq.push(['_trackPageview']);
-      (function() {
-          var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-          ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-  </r:script>
-
-    <r:script type="text/javascript">
       if (typeof(Zenbox) !== "undefined") {
         Zenbox.init({
           dropboxID:   "${grailsApplication.config.ZenDeskDropboxID?:20234067}",

--- a/app/grails-app/views/layouts/pubbootstrap.gsp
+++ b/app/grails-app/views/layouts/pubbootstrap.gsp
@@ -24,16 +24,7 @@
     <g:layoutHead/>
     <r:layoutResources/>
 
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', '${grailsApplication.config.kbplus.analytics.code}']);
-      _gaq.push(['_trackPageview']);
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </script>
+    <tmpl:/layouts/analytics />
   </head>
 
   <body class="public">


### PR DESCRIPTION
Refactor all google-analytics code into layouts/_analytics.gsp.

Do not load https://ssl.google-analytics.com/ga.js when config variable kbplus.analytics.code is not set by suppressing all google analytics code.
