### PR TITLE
fix nonfunctional Add Org Role button

### DIFF
--- a/app/grails-app/views/templates/_orgLinksModal.gsp
+++ b/app/grails-app/views/templates/_orgLinksModal.gsp
@@ -92,7 +92,7 @@
         return confirm('No role specified. Are you sure you want to link an Organisation without a role?');
       }
 
-      return false;
+      return true;
     }
 
 


### PR DESCRIPTION
The change 95f271a added a warning message if no role is selected, but disabled the add button if any role is selected.

This affects the modal dialog of "Add Org Link" on eg.
titleDetails/edit/1
licenseDetails/index/1
