### PR TITLE
export lower case issn eissn for KBPlus Import Format

### DIFF
--- a/app/web-app/WEB-INF/resources/kbplusimp.xsl
+++ b/app/web-app/WEB-INF/resources/kbplusimp.xsl
@@ -28,11 +28,11 @@ Consortium,
       </xsl:call-template>
       <!-- print_identifier -->
       <xsl:call-template name="csventry">
-        <xsl:with-param name="txt" select="./TitleIDs/ID[@namespace='ISSN']" />
+        <xsl:with-param name="txt" select="./TitleIDs/ID[@namespace='ISSN' or @namespace='issn']" />
       </xsl:call-template>
       <!-- online_identifier -->
       <xsl:call-template name="csventry">
-        <xsl:with-param name="txt" select="./TitleIDs/ID[@namespace='eISSN']" />
+        <xsl:with-param name="txt" select="./TitleIDs/ID[@namespace='eISSN' or @namespace='eissn']" />
       </xsl:call-template>
       <!-- date_first_issue_online -->
       <xsl:call-template name="csventry">


### PR DESCRIPTION
The "Exports"/"KBPlus Import Format" on the page packageDetails/show/1 uses ISSN and eISSN title id, but only if they are in capital letter. But there exist title ids in lower case because manually adding title ids in KBPlus automatically lowercases them. This pull request changes the xsl so that lower case title ids also gets exported.
