### PR TITLE
fix package link in type column

### DIFF
--- a/app/grails-app/views/globalDataSync/index.gsp
+++ b/app/grails-app/views/globalDataSync/index.gsp
@@ -50,7 +50,7 @@
               <td> <a href="${item.source.baseUrl}resource/show/${item.identifier}">${fieldValue(bean: item, field: "name")}</a></td>
               <td> <a href="${item.source.baseUrl}resource/show/${item.identifier}">${fieldValue(bean: item, field: "desc")}</a></td>
               <td> <a href="${item.source.uri}?verb=getRecord&identifier=${item.identifier}&metadataPrefix=${item.source.fullPrefix}">${item.source.name}</a></td>
-              <td> <a href="${item.source.baseUrl}search/index?qbe=g:packages">${item.displayRectype}</a></td>
+              <td> <a href="${item.source.baseUrl}search/index?qbe=g:1packages">${item.displayRectype}</a></td>
               <td>${item.kbplusCompliant?.value}</td>
               <td><g:link action="newCleanTracker" controller="globalDataSync" id="${item.id}" class="btn btn-success">Track(New)</g:link>
                   <g:link action="selectLocalPackage" controller="globalDataSync" id="${item.id}" class="btn btn-success">Track(Merge)</g:link></td>


### PR DESCRIPTION
The page "Global Data Download [Packages]" globalDataSync/index has a Type column containing a link labelled Package. It links to https://test-gokb.kuali.org/gokb/search/index?qbe=g:packages resulting in "Error 500: Internal Server Error", "NullPointerException", "Cannot get property 'title' on null object".

The correct link is https://test-gokb.kuali.org/gokb/search/index?qbe=g:1packages .
