### PR TITLE
fix comparison when endDate==null

### DIFF
--- a/app/grails-app/controllers/com/k_int/kbplus/PackageDetailsController.groovy
+++ b/app/grails-app/controllers/com/k_int/kbplus/PackageDetailsController.groovy
@@ -332,10 +332,17 @@ class PackageDetailsController {
         
        def packageInstance = Package.get(packageId)
 
-       if(packageInstance.startDate > date || packageInstance.endDate < date){
-        def errorMsg = "${packageInstance.name} start date is: ${sdf.format(packageInstance.startDate)} and end date is: ${sdf.format(packageInstance.endDate)}. You have selected to compare it on date ${sdf.format(date)}."
-          throw new IllegalArgumentException(errorMsg)
+       if (date < packageInstance.startDate) {
+         throw new IllegalArgumentException(
+           "${packageInstance.name} start date is ${sdf.format(packageInstance.startDate)}. " +
+           "Date to compare it on is ${sdf.format(date)}, this is before start date.")
        }
+       if (packageInstance.endDate && date > packageInstance.endDate){
+         throw new IllegalArgumentException(
+           "${packageInstance.name} end date is ${sdf.format(packageInstance.endDate)}. " +
+           "Date to compare it on is ${sdf.format(date)}, this is after end date.")
+       }
+
        result.pkgInsts.add(packageInstance)
 
        result.pkgDates.add(sdf.format(date))


### PR DESCRIPTION
Doing a Package Comparison with a package with endDate==null results in error message "Cannot format given Object as a Date" caused by sdf.format(packageInstance.endDate) in packageDetailsController.createCompareList(...).

This code fixes the wrong comparison of an endDate of null, and also improves the error message by splitting it into a separate message for startDate and endDate.
