### PR TITLE
Create ('Organisational Role', 'Licensor')

### DIFF
--- a/app/grails-app/conf/BootStrap.groovy
+++ b/app/grails-app/conf/BootStrap.groovy
@@ -360,8 +360,9 @@ class BootStrap {
   // Setup extra refdata
   def setupRefdata = { 
     // New Organisational Role
-    def sc_role = RefdataCategory.lookupOrCreate('Organisational Role', 'Package Consortia');
-    def or_licensee_role = RefdataCategory.lookupOrCreate('Organisational Role', 'Licensee');
+    RefdataCategory.lookupOrCreate('Organisational Role', 'Package Consortia');
+    RefdataCategory.lookupOrCreate('Organisational Role', 'Licensee');
+    RefdataCategory.lookupOrCreate('Organisational Role', 'Licensor');
 
     // -------------------------------------------------------------------
     // ONIX-PL Additions


### PR DESCRIPTION
'Licensor' is missing from the Add Org Link role selection list in licenseDetails/index/1. This fix adds Licensor to the BootStrap's setupRefData.

Code cleanup: remove unused local variables sc_role and or_licensee_role in setupRefdata.
