### PR TITLE
add dummy actor to handle empty AuditLog

### DIFF
--- a/app/grails-app/controllers/com/k_int/kbplus/DataManagerController.groovy
+++ b/app/grails-app/controllers/com/k_int/kbplus/DataManagerController.groovy
@@ -78,7 +78,8 @@ class DataManagerController {
     def actors_dms = []
     def actors_users = []
     def all_types = [ 'com.k_int.kbplus.Package','com.k_int.kbplus.License','com.k_int.kbplus.TitleInstance','com.k_int.kbplus.TitleInstancePackagePlatform' ]
-    def auditActors = AuditLogEvent.executeQuery('select distinct(al.actor) from AuditLogEvent as al where al.className in ( :l  )',[l:all_types])
+    def auditActors = AuditLogEvent.executeQuery(
+		'select distinct(al.actor) from AuditLogEvent as al where al.className in ( :l  )',[l:all_types]) + ['']
     def formal_role = com.k_int.kbplus.auth.Role.findByAuthority('INST_ADM')
     def rolesMa = com.k_int.kbplus.auth.UserOrg.executeQuery("select distinct(userorg.user.username) from UserOrg as userorg where userorg.formalRole = (:formal_role) and userorg.user.username in (:actors)",[formal_role:formal_role,actors:auditActors])
     auditActors.each {


### PR DESCRIPTION
When the AuditLog is empty, invoking `/dataManager/changeLog` creates an `org.hibernate.hql.ast.QuerySyntaxException` because of `userorg.user.username in (:actors)` with empty actors list.

Adding an empty string (dummy actor) resolves this issue.
