### PR TITLE
move duplicated code into codeStatus template

### DIFF
--- a/app/grails-app/views/issueEntitlement/show.gsp
+++ b/app/grails-app/views/issueEntitlement/show.gsp
@@ -88,8 +88,8 @@
               <g:set var="iecorestatus" value="${issueEntitlementInstance.getTIP()?.coreStatus(null)}"/>                 
               <dt>Core Status</dt>
               <dd> 
-<g:remoteLink url="[controller: 'ajax', action: 'getTipCoreDates', params:[tipID:issueEntitlementInstance.getTIP()?.id,title:issueEntitlementInstance.tipp?.title?.title]]" method="get" name="show_core_assertion_modal" onComplete="showCoreAssertionModal()"
-              update="magicArea">${iecorestatus?'True(Now)': (iecorestatus==null?'False(Never)':'False(Now)')}</g:remoteLink></dd>
+                <g:render template="/templates/coreStatus" model="${['issueEntitlement': issueEntitlementInstance]}"/>
+              </dd>
 
                 <g:if test="${issueEntitlementInstance?.tipp.hostPlatformURL}">
                     <dt>Title URL</dt>

--- a/app/grails-app/views/subscriptionDetails/index.gsp
+++ b/app/grails-app/views/subscriptionDetails/index.gsp
@@ -1,8 +1,4 @@
 <%@ page import="com.k_int.kbplus.Subscription" %>
-<%@ page import="java.text.SimpleDateFormat"%>
-<%
-  def dateFormater = new SimpleDateFormat(session.sessionPreferences?.globalDateFormat)
-%>
 <r:require module="annotations" />
 
 <!doctype html>
@@ -199,10 +195,7 @@
                     <g:xEditable owner="${ie}" type="date" field="endDate" />
                 </td>
                 <td>
-                <g:set var="iecorestatus" value="${ie.getTIP()?.coreStatus(params.asAt?dateFormater.parse(params.asAt):null)}"/>
-                <g:set var="core_checked" value="${params.asAt?:'Now'}"/>
-<g:remoteLink url="[controller: 'ajax', action: 'getTipCoreDates', params:[editable:editable,tipID:ie.getTIP()?.id,title:ie.tipp?.title?.title]]" method="get" name="show_core_assertion_modal" onComplete="showCoreAssertionModal()" class="editable-click"
-              update="magicArea">${iecorestatus?"True(${core_checked})": (iecorestatus==null?'False(Never)':"False(${core_checked})")}</g:remoteLink>
+                <g:render template="/templates/coreStatus" model="${['issueEntitlement': ie, 'date': params.asAt]}"/>
                <br/>
 
                <g:xEditableRefData owner="${ie}" field="coreStatus" config='CoreStatus'/>

--- a/app/grails-app/views/templates/_coreStatus.gsp
+++ b/app/grails-app/views/templates/_coreStatus.gsp
@@ -1,0 +1,13 @@
+<g:set var="tip" value="${issueEntitlement.getTIP()}" />
+<g:if test="${tip}">
+  <g:set var="dateFormatter" value="${new java.text.SimpleDateFormat(session.sessionPreferences?.globalDateFormat)}"/>
+  <g:set var="date" value="${date ? dateFormatter.parse(date) : null}"/>
+  <g:set var="status" value="${tip.coreStatus(date)}"/>
+  <g:set var="date_text" value="${date ?: (status?'Now':'Never')}"/>
+  <g:remoteLink url="[controller: 'ajax', action: 'getTipCoreDates', params:[tipID:tip.id,title:issueEntitlement.tipp?.title?.title]]"
+                method="get" name="show_core_assertion_modal" onComplete="showCoreAssertionModal()" class="editable-click"
+                update="magicArea">${ status ? "True(${date_text})" : "False(${date_text})" }</g:remoteLink>
+</g:if>
+<g:else>
+  Content Provider missing.  Add one as Org Link of the Package.
+</g:else>


### PR DESCRIPTION
When package lacks content provider this results in getTIP()==null and useless ajax popup.  Provide error/help message instead.
